### PR TITLE
Add support for a runtime.txt to determine miniconda version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ To use this buildpack specify the URI of the repository when pushing an IPython 
 
     cf push --buildpack https://github.com/p-a-c-o/ipython-notebook-buildpack.git
 
-This buildpack uses python 3.x. If you need python 2.x use
-
-    cf push --buildpack https://github.com/ihuston/ipython-notebook-buildpack.git
-
 As the IPython notebook uses Websockets you must access it on Cloud Foundry using port 4443, e.g. https://app-subdomain.cfapps.io:4443
 
+## Runtime
+
+Create a file named `runtime.txt` containing the Miniconda version you wish to use as runtime. Otherwise `Miniconda-latest-Linux-x86_64.sh` (python 2.x) will be used.
+
+Find different runtimes here: http://repo.continuum.io/miniconda/
+
+Use `Miniconda3-3.7.3-Linux-x86_64.sh` for python 3.x support.
 
 ## Notebook Dependencies
 The buildpack supports dependencies declaration using a `requirements.txt` file located in the root of the directory being pushed to Cloud Foundry.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The `ipython-notebook-buildpack` is a [Cloud Foundry][] buildpack for exposing [
 ## Usage
 To use this buildpack specify the URI of the repository when pushing an IPython Notebook file (or directory of files) to Cloud Foundry.
 
-    cf push --buildpack https://github.com/p-a-c-o/ipython-notebook-buildpack.git
+    cf push --buildpack https://github.com/ihuston/ipython-notebook-buildpack.git
 
 As the IPython notebook uses Websockets you must access it on Cloud Foundry using port 4443, e.g. https://app-subdomain.cfapps.io:4443
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ The `ipython-notebook-buildpack` is a [Cloud Foundry][] buildpack for exposing [
 ## Usage
 To use this buildpack specify the URI of the repository when pushing an IPython Notebook file (or directory of files) to Cloud Foundry.
 
+    cf push --buildpack https://github.com/p-a-c-o/ipython-notebook-buildpack.git
+
+This buildpack uses python 3.x. If you need python 2.x use
+
     cf push --buildpack https://github.com/ihuston/ipython-notebook-buildpack.git
 
 As the IPython notebook uses Websockets you must access it on Cloud Foundry using port 4443, e.g. https://app-subdomain.cfapps.io:4443

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,11 @@ WGET=$(which wget)
 CONDA_HOME="$1/.conda"
 CONDA_BIN="$CONDA_HOME/bin"
 
-MINICONDA_FILE="Miniconda3-3.7.3-Linux-x86_64.sh"
+if [ ! -f runtime.txt ]; then
+	MINICONDA_FILE="Miniconda-latest-Linux-x86_64.sh"
+else
+	MINICONDA_FILE=$(cat runtime.txt)
+fi
 MINICONDA_URI="http://repo.continuum.io/miniconda/$MINICONDA_FILE"
 MINICONDA_CACHE="$CACHE/$MINICONDA_FILE"
 

--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ MINICONDA_CACHE="$CACHE/$MINICONDA_FILE"
 echo "-----> Preparing Python Environment..."
 if [ ! -e $MINICONDA_CACHE ] ; then
 	echo "-----> Downloading Miniconda..."
-    #mkdir $CACHE
+	if [ ! -d $CACHE ]; then mkdir $CACHE; fi
 	$WGET -q -O $MINICONDA_CACHE $MINICONDA_URI
 	chmod +x $MINICONDA_CACHE
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -8,10 +8,10 @@ WGET=$(which wget)
 CONDA_HOME="$1/.conda"
 CONDA_BIN="$CONDA_HOME/bin"
 
-if [ ! -f runtime.txt ]; then
+if [ ! -e "$ROOT/runtime.txt" ]; then
 	MINICONDA_FILE="Miniconda-latest-Linux-x86_64.sh"
 else
-	MINICONDA_FILE=$(cat runtime.txt)
+	MINICONDA_FILE=$(cat "$ROOT/runtime.txt")
 fi
 MINICONDA_URI="http://repo.continuum.io/miniconda/$MINICONDA_FILE"
 MINICONDA_CACHE="$CACHE/$MINICONDA_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ echo "-----> Preparing Python Environment..."
 if [ ! -e $MINICONDA_CACHE ] ; then
 	echo "-----> Downloading Miniconda..."
 	if [ ! -d $CACHE ]; then mkdir $CACHE; fi
-	$WGET -q -O $MINICONDA_CACHE $MINICONDA_URI
+	$WGET -O $MINICONDA_CACHE $MINICONDA_URI
 	chmod +x $MINICONDA_CACHE
 fi
 if [ -e $CONDA_HOME ]; then rm -rf $CONDA_HOME; fi
@@ -29,10 +29,10 @@ if [ -e "$ROOT/requirements.txt" ]; then
     echo "-----> Installing additional requirements..."
 	$CONDA_BIN/conda install --yes --quiet --file "$ROOT/requirements.txt" #&> /dev/null
 fi
-
+#
 echo "-----> Changing hardcoded paths..."
-grep -rlI $ROOT . | xargs sed -ie "s|$ROOT|.|g"
-
+grep -rlI $ROOT . | xargs sed -i.bak "s|$ROOT|.|g"
+#
 if [ -e "$ROOT/additional_notebook_config.py" ]
 then
 	echo "-----> Additional IPython configuration file detected"

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ WGET=$(which wget)
 CONDA_HOME="$1/.conda"
 CONDA_BIN="$CONDA_HOME/bin"
 
-MINICONDA_FILE="Miniconda-3.3.0-Linux-x86_64.sh"
+MINICONDA_FILE="Miniconda-latest-Linux-x86_64.sh"
 MINICONDA_URI="http://repo.continuum.io/miniconda/$MINICONDA_FILE"
 MINICONDA_CACHE="$CACHE/$MINICONDA_FILE"
 

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ WGET=$(which wget)
 CONDA_HOME="$1/.conda"
 CONDA_BIN="$CONDA_HOME/bin"
 
-MINICONDA_FILE="Miniconda-latest-Linux-x86_64.sh"
+MINICONDA_FILE="Miniconda3-3.7.3-Linux-x86_64.sh"
 MINICONDA_URI="http://repo.continuum.io/miniconda/$MINICONDA_FILE"
 MINICONDA_CACHE="$CACHE/$MINICONDA_FILE"
 

--- a/bin/release
+++ b/bin/release
@@ -6,9 +6,6 @@ then
 fi
 
 echo "
----
-addons: ~
-config_vars: ~
 default_process_types:
-  web: .conda/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
+  web: ./.conda/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
 "


### PR DESCRIPTION
Changing the runtime to miniconda3 also changes the default python version to python 3.x. Not sure if runtime.txt is a good wording, but it is also used in the python buildpack.